### PR TITLE
add new option watchAnimationEnd

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -75,7 +75,7 @@ export default class FocusOverlay {
       // Reposition focus box on animationEnd based on the window object
       watchAnimationEnd: true,
       // Reposition focus box on scroll event (debounce: default 150ms)
-      debounceScroll: false,
+      debounceScroll: true,
       // Reposition focus box on resize event (debounce: default 150ms)
       debounceResize: true,
       // Defines the waiting time for the debounce function in milliseconds.

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import { FocusOverlayOptions } from './types';
 import {
   debounce,
   absolutePosition,
-  whichTransitionEvent,
+  getAnimatableEndEvent,
   nothing,
 } from './utils';
 
@@ -28,6 +28,8 @@ export default class FocusOverlay {
 
   private transitionEvent: string;
 
+  private animationEvent: string;
+
   private options: FocusOverlayOptions;
 
   private debouncedMoveFocusBox: () => void;
@@ -43,7 +45,8 @@ export default class FocusOverlay {
     this.previousTarget = null;
     this.nextTarget = null;
     this.timeout = setTimeout(nothing, 1);
-    this.transitionEvent = whichTransitionEvent();
+    this.transitionEvent = getAnimatableEndEvent('transition');
+    this.animationEvent = getAnimatableEndEvent('animation');
     this.options = {
       // Class added to the focus box
       class: 'focus-overlay',
@@ -69,8 +72,10 @@ export default class FocusOverlay {
       alwaysActive: false,
       // Reposition focus box on transitionEnd for focused elements
       watchTransitionEnd: true,
+      // Reposition focus box on animationEnd based on the window object
+      watchAnimationEnd: true,
       // Reposition focus box on scroll event (debounce: default 150ms)
-      debounceScroll: true,
+      debounceScroll: false,
       // Reposition focus box on resize event (debounce: default 150ms)
       debounceResize: true,
       // Defines the waiting time for the debounce function in milliseconds.
@@ -149,6 +154,12 @@ export default class FocusOverlay {
         }
         if (this.options.debounceResize) {
           window.addEventListener('resize', this.debouncedMoveFocusBox, false);
+        }
+        if (this.options.watchAnimationEnd) {
+          window.addEventListener(
+            this.animationEvent,
+            this.debouncedMoveFocusBox,
+          );
         }
       }
 
@@ -293,6 +304,12 @@ export default class FocusOverlay {
     if (this.options.debounceResize) {
       window.removeEventListener('resize', this.debouncedMoveFocusBox, false);
     }
+    if (this.options.watchAnimationEnd) {
+      window.removeEventListener(
+        this.animationEvent,
+        this.debouncedMoveFocusBox,
+      );
+    }
     this.cleanup();
     this.focusBox?.classList.remove(this.options.activeClass);
   }
@@ -372,6 +389,12 @@ export default class FocusOverlay {
     }
     if (this.options.debounceResize) {
       window.removeEventListener('resize', this.debouncedMoveFocusBox, false);
+    }
+    if (this.options.watchAnimationEnd) {
+      window.removeEventListener(
+        this.animationEvent,
+        this.debouncedMoveFocusBox,
+      );
     }
 
     this.options.onDestroy(this);

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,6 +13,7 @@ export interface FocusOverlayOptions {
   inactiveOnClick: boolean,
   alwaysActive: boolean,
   watchTransitionEnd: boolean,
+  watchAnimationEnd: boolean,
   debounceScroll: boolean,
   debounceResize: boolean,
   debounceMs: number,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -19,27 +19,44 @@ export const debounce = (callback: UnknownFunction, wait: number): UnknownFuncti
   };
 };
 
+const capitalize = (string:string): string => string.charAt(0).toUpperCase() + string.slice(1);
+
 /**
- * Cross browser transitionEnd event
- * https://davidwalsh.name/css-animation-callback
- * @return {String} Browser's supported transitionend type
+ * getAnimatableEndEvent
+ *
+ * returns the name of transitionend/animationend event for cross browser compatibility
+ *
+ * @param {string} type of the animatableEvent: 'transition' or 'animation'
+ * @returns {string} the transitionend/animationend event name
  */
-export const whichTransitionEvent = (): string => {
+export const getAnimatableEndEvent = (type: string): string => {
+  let animatableEvent = '';
+
   const el = document.createElement('fakeelement');
-  const transitions = {
-    transition: 'transitionend',
-    OTransition: 'oTransitionEnd',
-    MozTransition: 'transitionend',
-    WebkitTransition: 'webkitTransitionEnd',
+  const capitalType = capitalize(type);
+
+  const animations = {
+    [type]: `${type}end`,
+    [`O${capitalType}`]: `o${capitalType}End`,
+    [`Moz${capitalType}`]: `${type}end`,
+    [`Webkit${capitalType}`]: `webkit${capitalType}End`,
+    [`MS${capitalType}`]: `MS${capitalType}End`,
   };
 
-  Object.values(transitions).forEach((transition: string): string => {
-    if (el.style[(transition as any)] !== undefined) {
-      return transition;
+  const hasEventEnd = Object.keys(animations).some((item) => {
+    if (el.style[item as any] !== undefined) {
+      animatableEvent = animations[item];
+      return true;
     }
-    return '';
+
+    return false;
   });
-  return '';
+
+  if (!hasEventEnd) {
+    throw new Error(`${type}end is not supported in your web browser.`);
+  }
+
+  return animatableEvent;
 };
 
 // https://stackoverflow.com/a/32623832/8862005


### PR DESCRIPTION
New option: `watchAnimationEnd`

This new option will resolve our issues when opening a Modal. The new option attaches a new event listener to the window object and moves the focus box as soon as the animation has ended.

In order to support a variety of browsers, I extended the whichTransitionEvent function and made it more generic --> getAnimatableEndEvent, which can be used by both transition and animation.

